### PR TITLE
Basic Home Page

### DIFF
--- a/Web/Controller/Sessions.hs
+++ b/Web/Controller/Sessions.hs
@@ -7,7 +7,10 @@ import Web.View.Sessions.Home
 
 instance Controller SessionsController where
     action HomeAction = do
-        render HomeView
+        posts <- query @Post
+            |> orderByDesc #createdAt
+            |> fetch
+        render HomeView { .. }
 
     action NewSessionAction = Sessions.newSessionAction @User
     action CreateSessionAction = Sessions.createSessionAction @User

--- a/Web/Controller/Sessions.hs
+++ b/Web/Controller/Sessions.hs
@@ -3,8 +3,12 @@ module Web.Controller.Sessions where
 import Web.Controller.Prelude
 import Web.View.Sessions.New
 import qualified IHP.AuthSupport.Controller.Sessions as Sessions
+import Web.View.Sessions.Home
 
 instance Controller SessionsController where
+    action HomeAction = do
+        render HomeView
+
     action NewSessionAction = Sessions.newSessionAction @User
     action CreateSessionAction = Sessions.createSessionAction @User
     action DeleteSessionAction = Sessions.deleteSessionAction @User

--- a/Web/FrontController.hs
+++ b/Web/FrontController.hs
@@ -15,7 +15,7 @@ import Web.Controller.Sessions
 
 instance FrontController WebApplication where
     controllers = 
-        [ startPage WelcomeAction
+        [ startPage HomeAction
         , parseRoute @SessionsController
         -- Generator Marker
         , parseRoute @UsersController

--- a/Web/Types.hs
+++ b/Web/Types.hs
@@ -56,4 +56,5 @@ data SessionsController
     = NewSessionAction
     | CreateSessionAction
     | DeleteSessionAction
+    | HomeAction
     deriving (Eq, Show, Data)

--- a/Web/View/Sessions/Home.hs
+++ b/Web/View/Sessions/Home.hs
@@ -1,0 +1,15 @@
+module Web.View.Sessions.Home where
+import Web.View.Prelude
+
+data HomeView = HomeView
+
+instance View HomeView ViewContext where
+    html HomeView = [hsx|
+        <nav>
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href={NewSessionAction}>Login</a></li>
+                <li class="breadcrumb-item active">HomeView</li>
+            </ol>
+        </nav>
+        <h1>HomeView</h1>
+    |]

--- a/Web/View/Sessions/Home.hs
+++ b/Web/View/Sessions/Home.hs
@@ -1,15 +1,42 @@
 module Web.View.Sessions.Home where
 import Web.View.Prelude
 
-data HomeView = HomeView
+data HomeView = HomeView {posts :: [Post]}
 
 instance View HomeView ViewContext where
-    html HomeView = [hsx|
+    html HomeView { .. } = [hsx|
         <nav>
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href={NewSessionAction}>Login</a></li>
-                <li class="breadcrumb-item active">HomeView</li>
+                <li class="breadcrumb-item" ><a href={NewSessionAction}>Login</a></li>
+                <li class="breadcrumb-item"><a href={NewUserAction}>Register</a></li>
             </ol>
         </nav>
-        <h1>HomeView</h1>
+        <h1>Home</h1>
+        <table class="table table-responsive">
+            <thead>
+                <tr>
+                    <th>Posts</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>{forM_ posts renderPost}</tbody>
+        </table>
     |]
+
+
+renderPost post = [hsx|
+    <tr>
+        <td><h3>{get #title post}</h3></td>
+        <td colspan = "3" >{get #createdAt post |> timeAgo} </td>
+
+    </tr>
+    <tr>
+        <td>{get #body post}</td>
+    </tr>
+    <tr>
+        <td></td>
+        <td><a href={ShowPostAction (get #id post)}>Show</a></td>
+        <td><a href={EditPostAction (get #id post)} class="text-muted">edit</a></td>
+        <td><a href={DeletePostAction (get #id post)} class="js-delete text-muted">Delete</a></td>
+    </tr>
+|]


### PR DESCRIPTION
Login simply redirects to NewSessionAction, we need to set the returnAfterLogin url to make it go somewhere afterwards.
Register redirects to NewUserAction. We should either edit that view to go somewhere else afterwards (if we do not intend to use the default user actions and views from admin perspectives) or create a new action and view for registering (if we do want to keep the originals as admin level routes).

Posts are displayed, but without the ability to create a new one, we need to first check if the person is logged in.